### PR TITLE
fix uninitialized `suffix` variable

### DIFF
--- a/scripts/batch_face_swap.py
+++ b/scripts/batch_face_swap.py
@@ -239,7 +239,7 @@ def faceSwap(p, masks, image, finishedImages, invertMask, forced_filename, pathT
      
 
 def generateImages(p, path, searchSubdir, viewResults, divider, howSplit, saveMask, pathToSave, onlyMask, saveNoFace, overrideDenoising, overrideMaskBlur, invertMask, singleMaskPerImage, countFaces, maskSize, keepOriginalName, info, pathExisting, pathMasksExisting, pathToSaveExisting, selectedTab):
-    suffix = None
+    suffix = ''
     if selectedTab == "generateMasksTab":
         wasCountFaces = False
         finishedImages = []


### PR DESCRIPTION
I noticed this while merging (see #16), but I pulled down a clean version and it still happens. Crashes due to `suffix` being `None`. This fixes it by initializing it to the empty string, `''`.

```
  File "D:\ai\sdweb\modules\scripts.py", line 376, in run
    processed = script.run(p, *script_args)
  File "D:\ai\sdweb\extensions\batch-face-swap\scripts\batch_face_swap.py", line 729, in run
    finishedImages = generateImages(p, path, searchSubdir, viewResults, int(divider), howSplit, saveMask, pathToSave, onlyMask, saveNoFace, overrideDenoising, overrideMaskBlur, invertMask, singleMaskPerImage, countFaces, maskSize, keepOriginalName, info, pathExisting, pathMasksExisting, pathToSaveExisting, selectedTab)
  File "D:\ai\sdweb\extensions\batch-face-swap\scripts\batch_face_swap.py", line 333, in generateImages
    custom_save_image(p, image, pathToSave, forced_filename, suffix, info)
  File "D:\ai\sdweb\extensions\batch-face-swap\scripts\bfs_utils.py", line 126, in custom_save_image
    images.save_image(image, opts.outdir_img2img_samples, "", p.seed, p.prompt, opts.samples_format, info=info, p=p, forced_filename=forced_filename, suffix=suffix)
  File "D:\ai\sdweb\modules\images.py", line 526, in save_image
    file_decoration = namegen.apply(file_decoration) + suffix
TypeError: can only concatenate str (not "NoneType") to str
```

Crashes didn't happen when processing a single image, only when processing a directory.