### PR TITLE
Update install.py to restrict mediapipe-silicon to arm64

### DIFF
--- a/install.py
+++ b/install.py
@@ -3,7 +3,7 @@ import launch
 
 if not launch.is_installed("mediapipe") or not launch.is_installed("mediapipe-silicon"):
     name = "Batch Face Swap"
-    if platform.system() == "Darwin":
+    if platform.system() == "Darwin" and platform.machine == "arm64":
         # MacOS
         launch.run_pip("install mediapipe-silicon", "requirements for Batch Face Swap for MacOS")
     else:


### PR DESCRIPTION
Giving this a shot, on my intel Mac, while installing deps for Batch Face Swap, SD wouldn't start "stderr: ERROR: Could not find a version that satisfies the requirement mediapipe-silicon (from versions: none)" Hence, there's no mediapipe-silicon for non silicon CPUs :)